### PR TITLE
use SHELL instead of manually editing PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/revoxhere/duino-coin.git
 
 # Install rustup for compilation
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+SHELL ["/bin/bash", "--login", "-c"]
 
 # Download duino fasthash
 RUN wget https://server.duinocoin.com/fasthash/libducohash.tar.gz


### PR DESCRIPTION
when compiling this locally on my raspberry pi i had to change the image with this to fix it from randomly hanging. this causes no harm and will make it work in more places